### PR TITLE
add missing steps for Go

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -81,10 +81,16 @@ jobs:
           languages: ${{ matrix.language }}
           queries: security-and-quality
     
+      - name: Setup Go Environment
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+        if: matrix.language == 'go'
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@60168efe1c415ce0f5521ea06d5c2062adbeed1b # v3.28.17
         with:
           category: "/language:${{matrix.language}}"
-     
-
-          


### PR DESCRIPTION
This PR adds two steps for analysing Go code:

- setting up Go env with dependencies defined in the `go.mod`
- building the Go binary with dependency defined in the `go.mod`